### PR TITLE
Updates for August 2025

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -714,5 +714,17 @@
     "name": "LongPool",
     "tags": ["GoodLuckyBoom"],
     "link": "https://longpool.org/"
+  },
+  {
+    "id": 102,
+    "name": "molepool",
+    "tags": ["molepool.com"],
+    "link": "https://ltc.molepool.com"
+  },
+  {
+    "id": 103,
+    "name": "hash-hut",
+    "tags": ["hash-hut.net"],
+    "link": "https://hash-hut.net"
   }
 ]

--- a/pools.json
+++ b/pools.json
@@ -63,7 +63,7 @@
     "id": 9,
     "name": "AntPool",
     "addresses": ["LcNS6c8RddAMjewDrUAAi8BzecKoosnkN3"],
-    "tags": ["/AntPool/", "Mined By AntPool"],
+    "tags": ["/AntPool/", "Mined By AntPool", "Mined by AntPool"],
     "link": "https://www.antpool.com"
   },
   {
@@ -712,7 +712,7 @@
   {
     "id": 101,
     "name": "LongPool",
-    "tags": ["GoodLuckyBoommm"],
+    "tags": ["GoodLuckyBoom"],
     "link": "https://longpool.org/"
   }
 ]


### PR DESCRIPTION
- Fixes tags:
  - AntPool currently uses lowercase `by` in `Mined by AntPool`
  - LongPool erroneously had extra `mm`, coming from merge mining header
- Adds newly emerged pools:
  - molepool
  - hash-hut