### PR TITLE
Add HimPool mining pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -768,5 +768,12 @@
     "addresses": [],
     "tags": ["K1Pool.com"],
     "link": "https://k1pool.com/"
+  },
+  {
+    "id": 109,
+    "name": "HimPool",
+    "addresses": ["LWvJhoEirnd7LNvApVVDt1Z2fpb3eEDs9v", "LcnZfuE82YB5hhtiY5JPzPkh62mMPTA2Fc"],
+    "tags": ["HimPool.com", "/HimPool/"],
+    "link": "https://himpool.com"
   }
 ]


### PR DESCRIPTION
Adds HimPool to the Litecoin mining pool identification database.

**Changes:** 7 lines added, 0 lines modified — only HimPool entry appended.

**Entry:**
- id: 109
- Coinbase tags: `HimPool.com`, `/HimPool/`
- Addresses: `LWvJhoEirnd7LNvApVVDt1Z2fpb3eEDs9v` (pool), `LcnZfuE82YB5hhtiY5JPzPkh62mMPTA2Fc` (fee)
- Website: https://himpool.com

**Example block:** [3083036](https://explorer.cloverpool.com/ltc/block/3083036) (currently shows "unknown")

HimPool is a multi-coin mining pool with stratum servers in EU and India, supporting 27+ coins.